### PR TITLE
Generate application key in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,14 +64,14 @@ jobs:
       #     sed -i 's/DB_USERNAME=.*/DB_USERNAME=h273779_lgb/' .env
       #     sed -i 's/DB_PASSWORD=.*/DB_PASSWORD=iWY]RgUhnqiu/' .env
 
-      # - name: Generate key
-      #   env:
-      #     BROADCAST_DRIVER: log
-      #     PUSHER_APP_KEY: dummy_key
-      #     PUSHER_APP_SECRET: dummy_secret
-      #     PUSHER_APP_ID: dummy_id
-      #     PUSHER_APP_CLUSTER: mt1
-      #   run: php artisan key:generate --force
+      - name: Generate key
+        env:
+          BROADCAST_DRIVER: log
+          PUSHER_APP_KEY: dummy_key
+          PUSHER_APP_SECRET: dummy_secret
+          PUSHER_APP_ID: dummy_id
+          PUSHER_APP_CLUSTER: mt1
+        run: php artisan key:generate --force
 
       - name: Directory Permissions
         run: chmod -R 777 storage bootstrap/cache


### PR DESCRIPTION
Uncomment `php artisan key:generate` in `main.yml` to ensure a Laravel application key is generated during the CI/CD workflow.

The `php artisan key:generate` command was already present but commented out in the GitHub Actions workflow. Uncommenting it activates the step, which is crucial for Laravel applications to function securely by generating an application key during deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-b884c5a4-e8e9-486a-a2c9-cf191a7e1c47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b884c5a4-e8e9-486a-a2c9-cf191a7e1c47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

